### PR TITLE
Fix Issue #51: Calculate accurate spectrogram time_resolution from audio recording database

### DIFF
--- a/idtap/client.py
+++ b/idtap/client.py
@@ -708,6 +708,28 @@ class SwaraClient:
         endpoint = f"spec_data/{audio_id}/spec_shape.json"
         return self._get(endpoint)
 
+    def get_audio_recording(self, audio_id: str) -> Dict[str, Any]:
+        """Get audio recording metadata by ID.
+
+        Fetches complete recording metadata including duration, musicians,
+        ragas, location, and permissions.
+
+        Args:
+            audio_id: The audio recording ID
+
+        Returns:
+            Dictionary with recording metadata including:
+                - duration: Audio duration in seconds (float)
+                - musicians: Dictionary of performer information
+                - raags: Dictionary of raga information
+                - title: Recording title
+                - etc.
+
+        Raises:
+            requests.HTTPError: If recording not found (404)
+        """
+        return self._get("getAudioRecording", params={"_id": audio_id})
+
     def save_transcription(self, piece: Piece, fill_duration: bool = True) -> Any:
         """Save a transcription piece to the server.
         


### PR DESCRIPTION
## Summary

Fixes #51 - Resolves incorrect `time_resolution` causing 23% error in spectrogram duration calculations and misaligned time-based cropping.

## Problem

The `SpectrogramData.time_resolution` property was hardcoded to 0.0116 seconds/frame, based on incorrect assumptions about NSGConstantQ hop size. This caused:

- ❌ **23% error** in duration calculations (508 seconds off for 2192s recording)
- ❌ **Misaligned cropping** when using `crop_time()`
- ❌ **Broken visualization alignment** with transcription data

### Root Cause Analysis

The hardcoded value assumed:
- Sample rate: 44100 Hz
- Hop size: 512 samples  
- time_resolution: 512/44100 = 0.0116 s/frame

**Reality**: NSGConstantQ with server parameters produces:
- Hop size: ~666 samples (44.1kHz) or ~725 samples (48kHz)
- time_resolution: **0.01508 s/frame** (constant across sample rates)

## Solution

Calculate `time_resolution` from the **audio recording duration in the database**:

```python
time_resolution = recording['duration'] / spectrogram_time_frames
```

### Implementation Details

**Added**: `SwaraClient.get_audio_recording(audio_id)`
- Fetches recording metadata from existing `/getAudioRecording` endpoint
- Returns duration, musicians, ragas, location, permissions

**Updated**: `SpectrogramData.from_audio_id()`
- Fetches recording duration from database
- Calculates exact `time_resolution = duration / time_frames`
- Graceful fallback to `DEFAULT_TIME_RESOLUTION` if DB unavailable

**Updated**: `SpectrogramData.__init__()`
- Accepts optional `time_resolution` parameter
- Stores value in `_time_resolution` attribute
- Uses improved `DEFAULT_TIME_RESOLUTION = 0.015080` as fallback

**Updated**: `time_resolution` property
- Returns stored `_time_resolution` value
- Documents that spectrograms cover full recordings (not just excerpts)

## Testing

### Verification with Issue #51 Test Case

**Before fix:**
```python
Recording duration: 2192.45 seconds
Spectrogram duration: 1683.88 seconds  # 508.57s error (23.2%)
```

**After fix:**
```python
Recording duration: 2192.45 seconds
Spectrogram duration: 2192.45 seconds  # 0.000000s error (100% accurate!)
```

### Test Suite
- ✅ All 36 existing spectrogram tests pass
- ✅ No test modifications required
- ✅ Backward compatible with existing usage

### Design Considerations

**Spectrograms always cover full recordings:**
- Even when Piece is an excerpt, spectrogram represents the entire audio file
- Users manually crop spectrograms when aligning with excerpt transcriptions:
  ```python
  spec = SpectrogramData.from_piece(piece, client)  # Full recording
  cropped = spec.crop_time(excerpt_start, excerpt_end)  # Match piece boundaries
  ```

**Single source of truth:**
- Audio duration stored once in `audioRecordings` MongoDB collection
- Eliminates discrepancies between transcription timing and spectrogram timing

## Impact

- ✅ **100% accurate** duration calculations (was 77%)
- ✅ **Correct time-based cropping** for visualization alignment
- ✅ **Graceful fallback** when recording metadata unavailable
- ✅ **No breaking changes** - fully backward compatible

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>