### PR TITLE
Fix spectrogram frequency axis orientation

### DIFF
--- a/idtap/spectrogram.py
+++ b/idtap/spectrogram.py
@@ -111,6 +111,10 @@ class SpectrogramData:
         shape = tuple(metadata['shape'])  # [freq_bins, time_frames]
         data = np.frombuffer(decompressed, dtype=np.uint8).reshape(shape)
 
+        # Flip frequency axis so row 0 = lowest frequency (matches freq_bins ordering)
+        # Server data has row 0 = highest frequency, but we want row 0 = lowest
+        data = np.flipud(data)
+
         # Get exact audio duration from recording database
         time_resolution = None
         try:


### PR DESCRIPTION
## Summary
- Fixed frequency axis orientation in spectrogram data loading
- Server data has row 0 = highest frequency, but API expects row 0 = lowest
- This caused frequency cropping to select wrong spectrum regions (off by more than an octave)

## Changes
- Added `np.flipud()` in `SpectrogramData.from_audio_id()` after loading data from server
- Data is now correctly oriented: row 0 = lowest frequency, matching `freq_bins` property ordering
- All 36 spectrogram tests continue to pass

## Impact
- Fixes frequency alignment between spectrograms and pitch contours in visualizations
- Users should remove any `flipud()` calls they were using as workarounds

## Test Plan
- [x] All existing tests pass
- [x] Frequency bins now correctly correspond to data rows
- [x] Cropping now selects correct frequency ranges

🤖 Generated with [Claude Code](https://claude.com/claude-code)