### PR TITLE
feat: sync Python API with TypeScript codebase (#61)

### DIFF
--- a/idtap/classes/chikari.py
+++ b/idtap/classes/chikari.py
@@ -92,13 +92,15 @@ class Chikari:
     def to_json(self) -> Dict:
         return {
             'fundamental': self.fundamental,
-            'pitches': [p.to_json() for p in self.pitches],
             'uniqueId': self.unique_id,
         }
 
     @staticmethod
     def from_json(obj: Dict) -> 'Chikari':
         opts = humps.decamelize(obj)
-        pitches = [Pitch.from_json(p) for p in opts.get('pitches', [])]
-        opts['pitches'] = pitches
+        # Handle old format (with pitches) for backward compatibility
+        pitches_data = opts.get('pitches')
+        if pitches_data:
+            pitches = [Pitch.from_json(p) for p in pitches_data]
+            opts['pitches'] = pitches
         return Chikari(opts)  # type: ignore[arg-type]

--- a/idtap/query_types.py
+++ b/idtap/query_types.py
@@ -53,37 +53,8 @@ class SegmentationType(str, Enum):
     CONNECTED_SEQUENCE_OF_TRAJECTORIES = "connectedSequenceOfTrajectories"
 
 
-# Section categorization types (matching TypeScript SecCatType)
-class SecCatType(TypedDict, total=False):
-    """Section categorization structure."""
-    # Pre-Chiz Alap section
-    pre_chiz_alap: Dict[str, bool]
-    
-    # Alap section types
-    alap: Dict[str, bool]
-    
-    # Composition types
-    composition_type: Dict[str, bool]
-    
-    # Tempo/section types
-    comp_section_tempo: Dict[str, bool]
-    
-    # Tala types
-    tala: Dict[str, bool]
-    
-    # Other categories
-    improvisation: Dict[str, bool]
-    other: Dict[str, bool]
-    
-    # Top level category
-    top_level: Literal[
-        "Pre-Chiz Alap", 
-        "Alap", 
-        "Composition", 
-        "Improvisation", 
-        "Other", 
-        "None"
-    ]
+# Section categorization type alias (matching piece.py and database format)
+SecCatType = Dict[str, Union[Dict[str, bool], str]]
 
 
 # Phrase categorization types (matching TypeScript PhraseCatType)
@@ -187,15 +158,14 @@ class MultipleOptionType(TypedDict, total=False):
 
 # Default categorization structures
 def init_sec_categorization() -> SecCatType:
-    """Initialize default section categorization structure."""
+    """Initialize default section categorization structure.
+
+    Keys use display-string format matching the database and piece.py.
+    """
     return {
-        "pre_chiz_alap": {"Pre-Chiz Alap": False},
-        "alap": {
-            "Alap": False,
-            "Jor": False,
-            "Alap-Jhala": False
-        },
-        "composition_type": {
+        "Pre-Chiz Alap": {"Pre-Chiz Alap": False},
+        "Alap": {"Alap": False, "Jor": False, "Alap-Jhala": False},
+        "Composition Type": {
             "Dhrupad": False,
             "Bandish": False,
             "Thumri": False,
@@ -210,7 +180,7 @@ def init_sec_categorization() -> SecCatType:
             "Razakhani Gat": False,
             "Ferozkhani Gat": False,
         },
-        "comp_section_tempo": {
+        "Comp.-section/Tempo": {
             "Ati Vilambit": False,
             "Vilambit": False,
             "Madhya": False,
@@ -218,14 +188,10 @@ def init_sec_categorization() -> SecCatType:
             "Ati Drut": False,
             "Jhala": False,
         },
-        "tala": {
-            "Ektal": False,
-            "Tintal": False,
-            "Rupak": False
-        },
-        "improvisation": {"Improvisation": False},
-        "other": {"Other": False},
-        "top_level": "None"
+        "Tala": {"Ektal": False, "Tintal": False, "Rupak": False},
+        "Improvisation": {"Improvisation": False},
+        "Other": {"Other": False},
+        "Top Level": "None",
     }
 
 

--- a/idtap/tests/auth_logout_test.py
+++ b/idtap/tests/auth_logout_test.py
@@ -154,18 +154,20 @@ class TestSecureTokenStorage:
         """Test that clear_tokens removes all token files."""
         # Mock files exist
         mock_exists.return_value = True
-        
+
         storage = SecureTokenStorage()
-        
-        # Mock keyring operations
-        with patch('idtap.secure_storage.KEYRING_AVAILABLE', True), \
-             patch('idtap.secure_storage.keyring.delete_password') as mock_delete:
-            
+
+        # Create a mock keyring module if it doesn't exist (e.g. keyring not installed)
+        import idtap.secure_storage as ss
+        mock_keyring = MagicMock()
+        with patch.object(ss, 'KEYRING_AVAILABLE', True), \
+             patch.object(ss, 'keyring', mock_keyring, create=True):
+
             result = storage.clear_tokens()
-            
+
             # Verify keyring deletion was attempted
-            mock_delete.assert_called_once()
-            
+            mock_keyring.delete_password.assert_called_once()
+
             # Verify file deletions were attempted
             assert mock_unlink.call_count >= 1  # Should try to delete encrypted and plaintext files
             assert result is True

--- a/idtap/tests/chikari_test.py
+++ b/idtap/tests/chikari_test.py
@@ -8,9 +8,46 @@ from idtap.classes.pitch import Pitch
 # Test mirrors src/js/tests/chikari.test.ts
 
 def test_chikari_serialization():
+    """New format: to_json() only includes fundamental and uniqueId, no pitches."""
     pitches = [Pitch({'swara': 's', 'oct': 1}), Pitch({'swara': 'p'})]
     c = Chikari({'pitches': pitches, 'fundamental': 440})
     assert isinstance(c.unique_id, str)
     json_obj = c.to_json()
+    assert 'fundamental' in json_obj
+    assert 'uniqueId' in json_obj
+    assert 'pitches' not in json_obj
+    # Round-trip preserves fundamental and uniqueId
     copy = Chikari.from_json(json_obj)
+    assert copy.fundamental == c.fundamental
+    assert copy.unique_id == c.unique_id
     assert copy.to_json() == json_obj
+
+
+def test_chikari_from_json_old_format():
+    """Backward compat: from_json() handles old format with pitches array."""
+    old_json = {
+        'fundamental': 261.63,
+        'uniqueId': 'test-id-123',
+        'pitches': [
+            {'swara': 0, 'oct': 2, 'raised': True, 'logOffset': 0},
+            {'swara': 0, 'oct': 1, 'raised': True, 'logOffset': 0},
+        ]
+    }
+    c = Chikari.from_json(old_json)
+    assert c.fundamental == 261.63
+    assert c.unique_id == 'test-id-123'
+    assert len(c.pitches) == 2
+    assert c.pitches[0].swara == 0
+    assert c.pitches[0].oct == 2
+
+
+def test_chikari_from_json_new_format():
+    """New format: from_json() without pitches uses defaults."""
+    new_json = {
+        'fundamental': 261.63,
+        'uniqueId': 'test-id-456',
+    }
+    c = Chikari.from_json(new_json)
+    assert c.fundamental == 261.63
+    assert c.unique_id == 'test-id-456'
+    assert len(c.pitches) == 4  # default pitches


### PR DESCRIPTION
## Summary

Addresses sync gaps identified in issue #61 between the TypeScript and Python codebases:

- **Raga-derived chikari pitches**: `chikari_pitches` now returns 4 raga-aware pitches (Sa, Sa, Pa if present, Ga if unambiguous) instead of 2 hardcoded ones
- **Chikari serialization**: `to_json()` no longer serializes pitches (derived from raga at runtime, ~95% smaller); `from_json()` handles both old and new formats
- **`section_starts_grid` computed property**: Now derived from `phrase.is_section_start` flags instead of stored separately; removed from `to_json()` output
- **Polyphonic dual-string support**: `all_trajectories()` and `traj_start_times()` accept `string_idx` parameter; new `ensure_string_synchronization()` and `string_from_traj()` methods
- **Sarangi `possible_trajs`**: Added missing mapping for the 4th existing instrument
- **`query_types.py` cleanup**: Reconciled `SecCatType` keys with actual database display-string format
- **Bonus**: Fixed `auth_logout_test` failure in environments without `keyring` installed

**Skipped**: 12 missing instruments in enum (only 4 instruments in practice)

## Test plan

- [x] All 438 tests pass (was 437 + 1 failing, now 438 + 0 failing)
- [x] 14 new tests covering chikari pitches, polyphonic strings, section_starts_grid, and serialization
- [x] Backward compatibility verified for old JSON formats (chikari with pitches, piece with sectionStartsGrid)

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)